### PR TITLE
Fixed review for 1.0.1

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -30,10 +30,8 @@ run_if: ""
 
 deps:
   brew:
-  - name: git
   - name: curl
   apt_get:
-  - name: git
   - name: curl
 
 # Entry point. Never change this.

--- a/step.yml
+++ b/step.yml
@@ -49,6 +49,7 @@ inputs:
       summary: "User's API Key or Organization's API Key"
       description: "The authorization token to be used when uploading app"
       is_required: true
+      is_sensitive: true
   - owner_name: ""
     opts:
       title: "DeployGate: Owner Name"


### PR DESCRIPTION
Fixed this review pointed out
https://github.com/bitrise-io/bitrise-steplib/pull/1747

* Removed dependency for git
  * Because git is not use
* Added `is_sensitive` option for api_key