### PR TITLE
use valuefile for DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -45,7 +45,7 @@ parse_error_field() {
 
 upload_app # this will create the `output.json``
 
-envman add --key DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON < output.json
+envman add --key DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON --valuefile output.json
 
 if [[ "$(cat output.json | parse_error_field)" == "false" ]]; then
   # upload successfully


### PR DESCRIPTION
envman accepts only pipe for stdin.
https://github.com/bitrise-io/envman/blob/24a8f72875981710a8b21e60d81c4126a3af3c67/cli/add.go#L172

So now DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON is empty.
```
DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON=
```