### PR TITLE
is_expand=true is required for sensitive values

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -50,6 +50,7 @@ inputs:
       description: "The authorization token to be used when uploading app"
       is_required: true
       is_sensitive: true
+      is_expand: true
   - owner_name: ""
     opts:
       title: "DeployGate: Owner Name"


### PR DESCRIPTION
The current bitrise step specification has this restriction. Sensitive values come as environment names so expanding the variables is required. The old behavior assumed it was true but the current behavior force us to declare it explicitly.