### PR TITLE
Some confused due to curl command's failure messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeployGate - upload a single application file
 
-This is the offical step to upload your application file to DeployGate.  
+This is the offical step to upload your application file to DeployGate.
 
 This step requires some values so please see the document for more details. ref: https://docs.deploygate.com/reference#upload
 

--- a/step.sh
+++ b/step.sh
@@ -64,9 +64,10 @@ fi
 envman add --key DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON --valuefile "$output_file"
 
 cat "$output_file"
+echo
 
 if [[ "$(cat output.json | parse_error_field)" == "false" ]]; then
   info "Uploaded successfully."
 else
-  fatal "Your upload failed."
+  fatal "Upload failed."
 fi

--- a/step.yml
+++ b/step.yml
@@ -134,5 +134,5 @@ outputs:
   - DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON:
     opts:
       title: "DeployGate: API result json"
-      summary: "The raw json which Upload API has returned"
+      summary: "The raw json which Upload API has returned. Available iff the request has been sent to DeployGate server."
       description: "The raw json which Upload API has returned"


### PR DESCRIPTION
The current implementation tries to execute the following process even if `curl` fails so error messages will include curl's, bash's and ours. Such mixed messages prevent users to understand what is the actual cause of their step's failure.