### PR TITLE
String fields that start with ( caused request failures

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -18,7 +18,6 @@ fatal() {
 
 upload_app() {
   local -r all_fields=(
-      "file=@$app_path"
       "message=$message"
       "distribution_key=$distribution_key"
       "distribution_name=$distribution_name"
@@ -33,7 +32,7 @@ upload_app() {
       # skip
       continue
     else
-      fields+=("-F")
+      fields+=("--form-string")
       fields+=("$field")
     fi
   done
@@ -43,6 +42,7 @@ upload_app() {
     -H "Authorization: token $api_key" \
     -H "Accept: application/json" \
     -A "DeployGateUploadAppBitriseStep/$STEP_VERSION" \
+    -F "file=@$app_path" \
     "${fields[@]}" \
     "https://deploygate.com/api/users/$owner_name/apps"
 }


### PR DESCRIPTION
We must use --form-string to send literals instead of -F

ref:

Spec statements from https://curl.se/docs/manpage.html are below.

```
To support sending multipart mail messages, the syntax is extended as follows:
- name can be omitted: the equal sign is the first character of the argument,
- if data starts with '(', this signals to start a new multipart: it can be followed by a content type specification.
- a multipart can be terminated with a '=)' argument.
```