### PR TITLE
Use GITHUB_OUTPUT instead of set-output command

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,16 +15,16 @@ jobs:
         with:
           fetch-depth: 0 # for now...
       - id: version
-        run: echo "::set-output name=result::${{ github.event.inputs.version }}"
+        run: echo "result=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
       - id: current-version
-        run: echo "::set-output name=result::$(.ci/get-version)"
+        run: echo "result=$(.ci/get-version)" >> $GITHUB_OUTPUT
       - id: branch
         name: create a branch
         run: |
           readonly branch_name='bump/${{ steps.version.outputs.result }}'
 
           git switch -c "$branch_name"
-          echo "::set-output name=result::$branch_name"
+          echo "result=$branch_name" >> $GITHUB_OUTPUT
       - run: .ci/reflect-version '${{ steps.version.outputs.result }}'
       - name: commit and create a pull request
         run: |


### PR DESCRIPTION
It will fail since June 1st as https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ announced.